### PR TITLE
Add persistent data store and fetch

### DIFF
--- a/src/controllers/release-history.controller.ts
+++ b/src/controllers/release-history.controller.ts
@@ -2,18 +2,84 @@
 
 // import {inject} from '@loopback/context';
 
-import {param, post} from '@loopback/rest';
-import {fetchReleases} from '../lib/github';
+import {repository} from '@loopback/repository';
+import {get, param, post} from '@loopback/rest';
+import {fetchReleases, Release} from '../lib/github';
+import {DownloadCount} from '../models';
+import {DownloadCountRepository} from '../repositories';
 
 export class ReleaseHistoryController {
-  constructor() {}
+  constructor(
+    @repository(DownloadCountRepository)
+    public downloadCountRepository : DownloadCountRepository,
+  ) {}
+
+  @get('/downloads/{owner}/{repo}')
+  async getDownloadCounts(
+    @param.path.string('owner') owner: string,
+    @param.path.string('repo') repo: string,
+  ) {
+    const newReleases: Release[] = [];
+    const releases = await fetchReleases(owner, repo);
+    for (const release of releases) {
+      const newAssets: Array<{
+        id: string;
+        name: string;
+        downloadCount: number;
+        downloadCounts: Array<DownloadCount>;
+      }> = [];
+      for (const asset of release.releaseAssets.nodes) {
+
+        // Fetch the download history of the asset
+        const downloadCounts = await this.downloadCountRepository.find({
+          where: {
+            and: [{releaseId: release.id}, {assetId: asset.id}],
+          },
+          order: [
+            "timestamp ASC",
+          ],
+          fields: {downloadCount: true, timestamp: true}
+        });
+
+        newAssets.push(({
+          ...asset,
+          downloadCounts,
+        }));
+      }
+      const newRelease = {
+        ...release,
+      };
+      newRelease.releaseAssets.nodes = newAssets;
+      newReleases.push(newRelease);
+    }
+    return newReleases;
+  }
+
   @post('/releases/{owner}/{repo}')
   async getReleases(
     @param.path.string('owner') owner: string,
     @param.path.string('repo') repo: string,
   ) {
+    const allDownloads: DownloadCount[] = [];
+
+    const timestamp = (new Date()).toISOString();
     const releases = await fetchReleases(owner, repo);
-    console.log(releases);
+    releases.forEach(release => {
+      const releaseId = release.id;
+      const downloads = release.releaseAssets.nodes.map(asset => {
+        return new DownloadCount({
+          assetId: asset.id,
+          releaseId,
+          downloadCount: asset.downloadCount,
+          timestamp,
+        });
+      });
+      // Add them to the list
+      allDownloads.push(...downloads);
+    });
+    // this.downloadCountRepository.findAll();
+    await this.downloadCountRepository.createAll(allDownloads);
+
     return {
       hello: "world",
       owner,

--- a/src/controllers/release-history.controller.ts
+++ b/src/controllers/release-history.controller.ts
@@ -3,7 +3,7 @@
 // import {inject} from '@loopback/context';
 
 import {param, post} from '@loopback/rest';
-import {fetchAssets} from '../lib/github';
+import {fetchReleases} from '../lib/github';
 
 export class ReleaseHistoryController {
   constructor() {}
@@ -12,13 +12,13 @@ export class ReleaseHistoryController {
     @param.path.string('owner') owner: string,
     @param.path.string('repo') repo: string,
   ) {
-    const resp = await fetchAssets(owner, repo);
-    console.log(resp);
+    const releases = await fetchReleases(owner, repo);
+    console.log(releases);
     return {
       hello: "world",
       owner,
       repo,
-      releases: resp,
+      releases,
     };
   }
 }

--- a/src/datasources/db.datasource.config.json
+++ b/src/datasources/db.datasource.config.json
@@ -1,0 +1,6 @@
+{
+  "name": "db",
+  "connector": "memory",
+  "localStorage": "",
+  "file": "./data/db.json"
+}

--- a/src/datasources/db.datasource.ts
+++ b/src/datasources/db.datasource.ts
@@ -1,0 +1,36 @@
+import {
+  inject,
+  lifeCycleObserver,
+  LifeCycleObserver,
+  ValueOrPromise,
+} from '@loopback/core';
+import {juggler} from '@loopback/repository';
+import config from './db.datasource.config.json';
+
+@lifeCycleObserver('datasource')
+export class DbDataSource extends juggler.DataSource
+  implements LifeCycleObserver {
+  static dataSourceName = 'db';
+
+  constructor(
+    @inject('datasources.config.db', {optional: true})
+    dsConfig: object = config,
+  ) {
+    super(dsConfig);
+  }
+
+  /**
+   * Start the datasource when application is started
+   */
+  start(): ValueOrPromise<void> {
+    // Add your logic here to be invoked when the application is started
+  }
+
+  /**
+   * Disconnect the datasource when application is stopped. This allows the
+   * application to be shut down gracefully.
+   */
+  stop(): ValueOrPromise<void> {
+    return super.disconnect();
+  }
+}

--- a/src/datasources/index.ts
+++ b/src/datasources/index.ts
@@ -1,0 +1,1 @@
+export * from './db.datasource';

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -34,7 +34,7 @@ export const fetchReleases = async (owner: string, repo: string): Promise<Releas
     query ($owner: String!, $repo: String!) {
         repository(owner:$owner, name:$repo) {
           id
-          releases(last: 10) {
+          releases(first: 3, orderBy: {field: CREATED_AT, direction: DESC}) {
             nodes {
               id
               name

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -6,28 +6,30 @@ const graphqlWithAuth = graphql.defaults({
   }
 });
 
+export interface Release {
+  id: string;
+  name: string;
+  createdAt: string;
+  url: string;
+  releaseAssets: {
+    nodes: Array<{
+      id: string;
+      name: string;
+      downloadCount: number;
+    }>;
+  }
+}
+
 export interface AssetResponse {
   repository: {
     id: string;
     releases: {
-      nodes: Array<{
-        id: string;
-        name: string;
-        createdAt: string;
-        url: string;
-        releaseAssets: {
-          nodes: Array<{
-            id: string;
-            name: string;
-            downloadCount: number;
-          }>;
-        }
-      }>;
+      nodes: Array<Release>;
     }
   }
 }
 
-export const fetchAssets = async (owner: string, repo: string): Promise<AssetResponse> => {
+export const fetchReleases = async (owner: string, repo: string): Promise<Release[]> => {
   const resp = await graphqlWithAuth(`
     query ($owner: String!, $repo: String!) {
         repository(owner:$owner, name:$repo) {
@@ -56,5 +58,5 @@ export const fetchAssets = async (owner: string, repo: string): Promise<AssetRes
   if (!resp) {
     throw new Error("Failed to fetch data from Github");
   }
-  return resp as AssetResponse;
+  return (resp as AssetResponse).repository.releases.nodes;
 }

--- a/src/models/download-count.model.ts
+++ b/src/models/download-count.model.ts
@@ -1,0 +1,47 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class DownloadCount extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    generated: true,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  releaseId: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  assetId: string;
+
+  @property({
+    type: 'number',
+    required: true,
+    default: 0,
+  })
+  downloadCount: number;
+
+  @property({
+    type: 'date',
+    required: true,
+  })
+  timestamp: string;
+
+
+  constructor(data?: Partial<DownloadCount>) {
+    super(data);
+  }
+}
+
+export interface DownloadCountRelations {
+  // describe navigational properties here
+}
+
+export type DownloadCountWithRelations = DownloadCount & DownloadCountRelations;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './download-count.model';

--- a/src/repositories/download-count.repository.ts
+++ b/src/repositories/download-count.repository.ts
@@ -1,0 +1,16 @@
+import {DefaultCrudRepository} from '@loopback/repository';
+import {DownloadCount, DownloadCountRelations} from '../models';
+import {DbDataSource} from '../datasources';
+import {inject} from '@loopback/core';
+
+export class DownloadCountRepository extends DefaultCrudRepository<
+  DownloadCount,
+  typeof DownloadCount.prototype.id,
+  DownloadCountRelations
+> {
+  constructor(
+    @inject('datasources.db') dataSource: DbDataSource,
+  ) {
+    super(DownloadCount, dataSource);
+  }
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './download-count.repository';


### PR DESCRIPTION
Persist download counts to an in-memory `json` file as a database for now.

This PR will store the same download count even if the count has not changed. We should eventually set it so that it only updates the timestamp if the count did not change.